### PR TITLE
[FIX]: Fix broken links in the README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Gutenberg Block Unit Test
 
-[![WordPress plugin](https://img.shields.io/wordpress/plugin/dt/block-unit-test.svg?style=flat)](https://wordpress.org/plugins/block-unit-test/) [![WordPress plugin](https://img.shields.io/wordpress/plugin/v/block-unit-test.svg?style=flat)](https://wordpress.org/plugins/block-unit-test/) [![WordPress](https://img.shields.io/wordpress/v/block-unit-test.svg?style=flat)]() [![License](https://img.shields.io/badge/license-GPL--3.0%2B-red.svg)](https://github.com/richtabor/block-unit-test/blob/master/license.txt)
+[![WordPress plugin](https://img.shields.io/wordpress/plugin/dt/block-unit-test.svg?style=flat)](https://wordpress.org/plugins/block-unit-test/) [![WordPress plugin](https://img.shields.io/wordpress/plugin/v/block-unit-test.svg?style=flat)](https://wordpress.org/plugins/block-unit-test/) [![WordPress](https://img.shields.io/wordpress/v/block-unit-test.svg?style=flat)]() [![License](https://img.shields.io/badge/license-GPL--3.0%2B-red.svg)](https://github.com/godaddy/block-unit-test/blob/master/LICENSE)
 
 Testing every core block — and every variation of every block — is no small task. That's why I built the Block Unit Test WordPress plugin. Deploy the Block Unit Test WordPress plugin and review every core Gutenberg block to ensure your theme fully supports Gutenberg. [Keep reading...](https://richtabor.com/gutenberg-block-unit-test/)
 
@@ -16,23 +16,23 @@ Testing every core block — and every variation of every block — is no small 
 4. You will find a new page added, titled "Block Unit Test". Each of the core Gutenberg blocks will be added here for you to start testing.
 
 ## Development ##
-1. Clone the GitHub repository: `https://github.com/that-plugin-company/block-unit-test.git`
+1. Clone the GitHub repository: `https://github.com/godaddy/block-unit-test.git`
 2. Browse to the folder in the command line.
 3. Run the `npm install` command to install the plugin's dependencies within a /node_modules/ folder.
 4. Develop stuff.
 5. Run the `build` gulp task to process build files and generate a zip.
 
 ## Bugs ##
-If you find a 🐞 or an issue, [create an issue](https://github.com/thatplugincompany/block-unit-test/issues/new).
+If you find a 🐞 or an issue, [create an issue](https://github.com/godaddy/block-unit-test/issues/new).
 
 ## Contributions ##
-Please read the [guidelines for contributing](https://github.com/thatplugincompany/block-unit-test/blob/master/CONTRIBUTING.md) to the Block Unit Test. Anyone is welcome to contribute!
+Please read the [guidelines for contributing](https://github.com/godaddy/block-unit-test/blob/master/CONTRIBUTING.md) to the Block Unit Test. Anyone is welcome to contribute!
 
 There are various ways you can contribute:
 
-1. Raise an [Issue](https://github.com/thatplugincompany/block-unit-test/issues/new) on GitHub
+1. Raise an [Issue](https://github.com/godaddy/block-unit-test/issues/new) on GitHub
 2. Send a pull request with your changes and/or bug fixes
-3. Provide feedback and suggestions on [enhancements](https://github.com/thatplugincompany/block-unit-test/issues?direction=desc&labels=Enhancement&page=1&sort=created&state=open)
+3. Provide feedback and suggestions on [enhancements](https://github.com/godaddy/block-unit-test/issues?direction=desc&labels=Enhancement&page=1&sort=created&state=open)
 
 ## Want a Gutenberg-ready WordPress theme?
 Meet [Tabor](https://themebeans.com/themes/tabor), a Gutenberg WordPress theme built for professional writers and content marketing. With full support for OptinMonster, Yoast, Schema and more, Tabor is the theme you need to grow your audience. With Tabor and Gutenberg, writing in WordPress is finally fun again.


### PR DESCRIPTION
Some URL's seemed to be outdated, switched from github.com/that-plugin-company, github.com/that-plugin-company or github.com/richtabor to https://github.com/godaddy.